### PR TITLE
Fixed transfer logging when mod_vroot is active.

### DIFF
--- a/mod_vroot.c
+++ b/mod_vroot.c
@@ -1838,7 +1838,7 @@ static cmdtable vroot_cmdtab[] = {
    * the path before the log record is written. By moving to the CMD phase,
    * The log records are corrected.
    */
-  { CMD,                C_APPE, G_NONE, vroot_log_retr, FALSE, FALSE },
+  { CMD,                C_APPE, G_NONE, vroot_log_stor, FALSE, FALSE },
   { CMD,                C_RETR, G_NONE, vroot_log_retr, FALSE, FALSE },
   { CMD,                C_STOR, G_NONE, vroot_log_stor, FALSE, FALSE },
 

--- a/mod_vroot.c
+++ b/mod_vroot.c
@@ -1833,6 +1833,14 @@ static cmdtable vroot_cmdtab[] = {
   { POST_CMD_ERR,	C_RETR,	G_NONE, vroot_log_retr, FALSE, FALSE },
   { POST_CMD,		C_STOR,	G_NONE, vroot_log_stor, FALSE, FALSE },
   { POST_CMD_ERR,	C_STOR,	G_NONE, vroot_log_stor, FALSE, FALSE },
+  /*
+   * POST_CMD/POST_CMD_ERR are still too late in the process to correct
+   * the path before the log record is written. By moving to the CMD phase,
+   * The log records are corrected.
+   */
+  { CMD,                C_APPE, G_NONE, vroot_log_retr, FALSE, FALSE },
+  { CMD,                C_RETR, G_NONE, vroot_log_retr, FALSE, FALSE },
+  { CMD,                C_STOR, G_NONE, vroot_log_stor, FALSE, FALSE },
 
   { 0, NULL }
 };


### PR DESCRIPTION
I I forked mod_vroot to fix the transfer logging bug that occurs for virtual users when mod_vroot is active. Take a look and see what you think. It fixes the logs for me.
