### PR TITLE
fix: mod crash caused by the nonfatal-attempt cmd error raised in mod…

### DIFF
--- a/mod_vroot.c
+++ b/mod_vroot.c
@@ -595,6 +595,7 @@ MODRET vroot_post_pass(cmd_rec *cmd) {
 MODRET vroot_post_pass_err(cmd_rec *cmd) {
   if (vroot_engine == TRUE) {
     const void *hint;
+    
     /* Look for any notes/hints attached to this command which might indicate
      * that it is not a real PASS command error, but rather a fake command
      * dispatched for e.g. logging/handling by other modules.  We pay attention
@@ -614,8 +615,6 @@ MODRET vroot_post_pass_err(cmd_rec *cmd) {
       }
 
       vroot_alias_free();
-    } else {
-      pr_log_debug(DEBUG5, MOD_VROOT_VERSION ": vroot 'mod_sftp.nonfatal-attempt' detected");
     }
 
   }


### PR DESCRIPTION
Upgraded from proftpd 1.3.7a to 1.3.7b, following commit introduced the new "non-fatal attempt" pass cmd error during mod_sftp authentication phase, which causes this mod crash probably due to the invalidate memory access. Use the same technique as the "modules/mod_auth.c", this PR introduces the same pass cmd error detection to ignore if the cmd has the "mod_sftp.nonfatal-attempt" note attached.

https://github.com/proftpd/proftpd/commit/52ae95cb37f827b23a5fade567c0500f4c0aeabe