### PR TITLE
Handle an edge case in timing, where the VRoot FS might be registered…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ config.status
 autom4te.cache
 mod_vroot.h
 .libs
+*.a
 .*.swp
 *.la
 *.lo

--- a/mod_vroot.c
+++ b/mod_vroot.c
@@ -1,7 +1,7 @@
 /*
  * ProFTPD: mod_vroot -- a module implementing a virtual chroot capability
  *                       via the FSIO API
- * Copyright (c) 2002-2019 TJ Saunders
+ * Copyright (c) 2002-2022 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -395,6 +395,11 @@ MODRET vroot_post_pass(cmd_rec *cmd) {
 
     /* If not chrooted, unregister vroot. */
     if (session.chroot_path == NULL) {
+
+      /* mod_auth_file may have opened files using our FS. */
+      (void) pr_auth_endpwent(session.pool);
+      (void) pr_auth_endgrent(session.pool);
+
       if (pr_unregister_fs("/") < 0) {
         pr_log_debug(DEBUG2, MOD_VROOT_VERSION
           ": error unregistering vroot: %s", strerror(errno));
@@ -426,8 +431,14 @@ MODRET vroot_post_pass(cmd_rec *cmd) {
 
 MODRET vroot_post_pass_err(cmd_rec *cmd) {
   if (vroot_engine == TRUE) {
+
     /* If not chrooted, unregister vroot. */
     if (session.chroot_path == NULL) {
+
+      /* mod_auth_file may have opened files using our FS. */
+      (void) pr_auth_endpwent(session.pool);
+      (void) pr_auth_endgrent(session.pool);
+
       if (pr_unregister_fs("/") < 0) {
         pr_log_debug(DEBUG2, MOD_VROOT_VERSION
           ": error unregistering vroot: %s", strerror(errno));

--- a/mod_vroot.h.in
+++ b/mod_vroot.h.in
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_vroot
- * Copyright (c) 2016-2019 TJ Saunders
+ * Copyright (c) 2016-2022 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,7 +27,7 @@
 
 #include "conf.h"
 
-#define MOD_VROOT_VERSION			"mod_vroot/0.9.8"
+#define MOD_VROOT_VERSION			"mod_vroot/0.9.9"
 
 /* Make sure the version of proftpd is as necessary. */
 #if PROFTPD_VERSION_NUMBER < 0x0001030602


### PR DESCRIPTION
…, _and_

used by _e.g._ mod_auth_file to open AuthUserFile, AuthGroupFile -- but then
there is no DefaultRoot configured, so we unregister the FS, leaving those
already opened files with a dangling pointer to our FS.  And this, in turn,
leads to a segfault.

Addresses ProFTPD Issue #1274.