### PR TITLE
Update the CodeQL GitHub Action to v3, per https://github.blog/change…

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
           ./configure --with-modules=mod_sftp:mod_vroot
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           config-file: contrib/mod_vroot/.codeql.yml
@@ -64,7 +64,7 @@ jobs:
           make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
           checkout_path: contrib/mod_vroot


### PR DESCRIPTION
…log/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/